### PR TITLE
Support plugconf

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,6 +15,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/haya14busa/go-vimlparser"
+  packages = [".","ast","go","token"]
+  revision = "ba41116981f22b72c0063fa9fef4ed241a743113"
+
+[[projects]]
+  branch = "master"
   name = "github.com/jbenet/go-context"
   packages = ["io"]
   revision = "d14ea06fba99483203c19d92cfcd13ebe73135f4"
@@ -79,6 +85,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2c97658953a33cb539a7ace4c75d586c2e6310c6a7a8b609f1e3f453a360c9c2"
+  inputs-digest = "eb374d64f933b0f2807488fa56af285205e0db874c44b418cde63565d6c67bb5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -148,7 +148,7 @@ func (cmd *addCmd) doAdd(from, reposPath string) error {
 		return errors.New("could not write to lock.json: " + err.Error())
 	}
 
-	// Rebuild start dir
+	// Rebuild ~/.vim/pack/volt dir
 	err = (&rebuildCmd{}).doRebuild(false)
 	if err != nil {
 		return errors.New("could not rebuild " + pathutil.VimVoltDir() + ": " + err.Error())

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -201,7 +201,7 @@ func (cmd *getCmd) doGet(reposPathList []string, flags *getFlagsType, lockJSON *
 			return errors.New("could not write to lock.json: " + err.Error())
 		}
 
-		// Rebuild start dir
+		// Rebuild ~/.vim/pack/volt dir
 		err = (&rebuildCmd{}).doRebuild(false)
 		if err != nil {
 			return errors.New("could not rebuild " + pathutil.VimVoltDir() + ": " + err.Error())

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -233,15 +233,20 @@ const (
 
 // This function is executed in goroutine of each plugin
 func (cmd *getCmd) getParallel(reposPath string, repos *lockjson.Repos, flags *getFlagsType, done chan getParallelResult) {
-	// Get HEAD hash string
-	fromHash, err := getReposHEAD(reposPath)
-	if err != nil {
-		logger.Error("Failed to get HEAD commit hash: " + err.Error())
-		done <- getParallelResult{
-			reposPath: reposPath,
-			status:    fmt.Sprintf("%s %s : install failed", statusPrefixFailed, reposPath),
+	// Normally, when upgraded is true, repos is also non-nil.
+	var fromHash string
+	if flags.upgrade && pathutil.Exists(pathutil.FullReposPathOf(reposPath)) {
+		// Get HEAD hash string
+		var err error
+		fromHash, err = getReposHEAD(reposPath)
+		if err != nil {
+			logger.Error("Failed to get HEAD commit hash: " + err.Error())
+			done <- getParallelResult{
+				reposPath: reposPath,
+				status:    fmt.Sprintf("%s %s : install failed", statusPrefixFailed, reposPath),
+			}
+			return
 		}
-		return
 	}
 
 	var status string
@@ -299,7 +304,6 @@ func (cmd *getCmd) getParallel(reposPath string, repos *lockjson.Repos, flags *g
 	}
 
 	// Show old and new revisions: "upgraded ({from}..{to})".
-	// Normally, when upgraded is true, repos is also non-nil.
 	if upgraded && repos != nil {
 		status = fmt.Sprintf("%s %s : upgraded (%s..%s)", statusPrefixUpgraded, reposPath, fromHash, toHash)
 	}

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -93,11 +93,11 @@ Command
   plugconf list [-a]
     List all user plugconfs. If -a option was given, list also system plugconfs.
 
-  plugconf bundle
+  plugconf export
     Outputs bundled plugconf to stdout.
 
-  plugconf unbundle
-    Input bundled plugconf (volt plugconf bundle) from stdin, unbundle the plugconf, and put files to each plugin's plugconf.
+  plugconf import
+    Input bundled plugconf (volt plugconf export) from stdin, import the plugconf, and put files to each plugin's plugconf.
 
   rebuild [-full]
     Rebuild ~/.vim/pack/volt/ directory

--- a/cmd/plugconf.go
+++ b/cmd/plugconf.go
@@ -223,6 +223,7 @@ func (cmd *plugconfCmd) generateBundlePlugconf(exportAll bool, reposList []lockj
 		} else {
 			plugconf[repos.Path] = parsed
 			funcCap += len(parsed.functions) + 1 /* +1 for s:config() */
+			reposID += 1
 		}
 	}
 	cmd.sortByDepends(reposList, plugconf)
@@ -509,15 +510,15 @@ func (cmd *plugconfCmd) makeBundledPlugConf(exportAll bool, reposList []lockjson
 			}
 			if p.configFunc != "" {
 				functions = append(functions, cmd.convertToDecodableFunc(p.configFunc, p.reposPath, p.reposID))
+				var pattern string
+				if p.loadOn == loadOnStart || p.loadOnArg == "" {
+					pattern = "*"
+				} else {
+					pattern = p.loadOnArg
+				}
+				autocommands = append(autocommands, fmt.Sprintf("  autocmd %s %s call s:config_%d()", string(p.loadOn), pattern, p.reposID))
 			}
 			functions = append(functions, p.functions...)
-			var pattern string
-			if p.loadOn == loadOnStart || p.loadOnArg == "" {
-				pattern = "*"
-			} else {
-				pattern = p.loadOnArg
-			}
-			autocommands = append(autocommands, fmt.Sprintf("  autocmd %s %s call s:config_%d()", string(p.loadOn), pattern, p.reposID))
 		}
 	}
 	return []byte(fmt.Sprintf(`if exists('g:loaded_volt_system_bundled_plugconf')

--- a/cmd/plugconf.go
+++ b/cmd/plugconf.go
@@ -184,7 +184,7 @@ func (*plugconfCmd) doList(args []string) error {
 	return nil
 }
 
-// Output bundle plugconf content
+// Output bundled plugconf content
 func (cmd *plugconfCmd) doBundle(args []string) error {
 	isSystem := len(args) != 0 && args[0] == "-system"
 
@@ -208,7 +208,7 @@ func (cmd *plugconfCmd) doBundle(args []string) error {
 		return err
 	}
 
-	// Output bundle plugconf content
+	// Output bundled plugconf content
 	output, merr := cmd.generateBundlePlugconf(isSystem, reposList)
 	if merr != nil {
 		for _, err := range merr.Errors {

--- a/cmd/plugconf.go
+++ b/cmd/plugconf.go
@@ -303,10 +303,6 @@ func (cmd *plugconfCmd) parsePlugConf(plugConf string, reposID int, reposPath st
 		return nil, parseErr
 	}
 
-	if configFunc == "" {
-		return nil, errors.New("no s:config() function in plugconf: " + plugConf)
-	}
-
 	return &parsedPlugconf{
 		reposID:    reposID,
 		reposPath:  reposPath,
@@ -379,7 +375,9 @@ func (cmd *plugconfCmd) makeBundledPlugConf(exportAll bool, reposList []lockjson
 			if exportAll && p.loadOnFunc != "" {
 				functions = append(functions, cmd.convertToDecodableFunc(p.loadOnFunc, p.reposPath, p.reposID))
 			}
-			functions = append(functions, cmd.convertToDecodableFunc(p.configFunc, p.reposPath, p.reposID))
+			if p.configFunc != "" {
+				functions = append(functions, cmd.convertToDecodableFunc(p.configFunc, p.reposPath, p.reposID))
+			}
 			functions = append(functions, p.functions...)
 			var pattern string
 			if p.loadOn == loadOnStart || p.loadOnArg == "" {

--- a/cmd/plugconf.go
+++ b/cmd/plugconf.go
@@ -228,8 +228,8 @@ func (cmd *plugconfCmd) generateBundlePlugconf(isSystem bool, reposList []lockjs
 	for _, repos := range reposList {
 		var parsed *parsedPlugconf
 		var err error
-		user := pathutil.UserPlugConfOf(repos.Path)
-		system := pathutil.SystemPlugConfOf(repos.Path)
+		user := pathutil.UserPlugconfOf(repos.Path)
+		system := pathutil.SystemPlugconfOf(repos.Path)
 		if pathutil.Exists(user) {
 			parsed, err = cmd.parsePlugConf(user, parsedList, repos.Path)
 		} else if pathutil.Exists(system) {

--- a/cmd/plugconf.go
+++ b/cmd/plugconf.go
@@ -4,11 +4,17 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"strings"
 
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/vim-volt/volt/lockjson"
 	"github.com/vim-volt/volt/logger"
 	"github.com/vim-volt/volt/pathutil"
+
+	"github.com/haya14busa/go-vimlparser"
+	"github.com/haya14busa/go-vimlparser/ast"
 )
 
 type plugconfFlagsType struct {
@@ -154,11 +160,192 @@ func (*plugconfCmd) doList(args []string) error {
 	return nil
 }
 
-func (*plugconfCmd) doBundle(_ []string) error {
+// Output bundle plugconf content
+func (cmd *plugconfCmd) doBundle(_ []string) error {
+	// Read lock.json
+	lockJSON, err := lockjson.Read()
+	if err != nil {
+		return errors.New("could not read lock.json: " + err.Error())
+	}
 
-	// TODO
+	// Find active profile
+	profile, err := lockJSON.Profiles.FindByName(lockJSON.ActiveProfile)
+	if err != nil {
+		// this must not be occurred because lockjson.Read()
+		// validates that the matching profile exists
+		return err
+	}
 
+	// Get active profile's repos list
+	reposList, err := lockJSON.GetReposListByProfile(profile)
+	if err != nil {
+		return err
+	}
+
+	// Output bundle plugconf content
+	output, merr := cmd.generateBundlePlugconf(reposList)
+	for _, err := range merr.Errors {
+		// Show vim script parse errors
+		logger.Warn(err.Error())
+	}
+	os.Stdout.Write(output)
 	return nil
+}
+
+func (cmd *plugconfCmd) generateBundlePlugconf(reposList []lockjson.Repos) ([]byte, *multierror.Error) {
+	// Parse plugconfs and make parsed plugconf info
+	var merr *multierror.Error
+	var parsedList []parsedPlugconf
+	var funcCap int
+	for _, repos := range reposList {
+		var parsed *parsedPlugconf
+		var err error
+		user := pathutil.UserPlugConfOf(repos.Path)
+		system := pathutil.SystemPlugConfOf(repos.Path)
+		if pathutil.Exists(user) {
+			parsed, err = cmd.parsePlugConf(user, parsedList)
+		} else if pathutil.Exists(system) {
+			parsed, err = cmd.parsePlugConf(system, parsedList)
+		}
+		if err != nil {
+			merr = multierror.Append(merr, err)
+		} else {
+			parsedList = append(parsedList, *parsed)
+			funcCap += len(parsed.functions) + 1 /* +1 for s:config() */
+		}
+	}
+	return cmd.makeBundledPlugConf(parsedList, funcCap), merr
+}
+
+type loadOnType string
+
+const (
+	loadOnStart    loadOnType = "VimEnter"
+	loadOnFileType            = "FileType"
+	loadOnExcmd               = "CmdUndefined"
+)
+
+type parsedPlugconf struct {
+	number     int
+	configFunc string
+	functions  []string
+	loadOn     loadOnType
+}
+
+func (cmd *plugconfCmd) parsePlugConf(plugConf string, parsedList []parsedPlugconf) (*parsedPlugconf, error) {
+	bytes, err := ioutil.ReadFile(plugConf)
+	if err != nil {
+		return nil, err
+	}
+	src := string(bytes)
+
+	file, err := vimlparser.ParseFile(strings.NewReader(src), plugConf, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var loadOn loadOnType
+	var configFunc string
+	var functions []string
+	var parseErr error
+
+	// Inspect nodes and get above values from plugconf script
+	ast.Inspect(file, func(node ast.Node) bool {
+		// Cast to function node (return if it's not a function node)
+		var fn *ast.Function
+		if f, ok := node.(*ast.Function); !ok {
+			return true
+		} else {
+			fn = f
+		}
+
+		// Get function name
+		var name string
+		if ident, ok := fn.Name.(*ast.Ident); !ok {
+			return true
+		} else {
+			name = ident.Name
+		}
+
+		switch name {
+		case "s:start_on":
+			var err error
+			loadOn, err = cmd.inspectReturnValue(fn)
+			if err != nil {
+				parseErr = err
+			}
+		case "s:config":
+			configFunc = cmd.extractBody(fn, src)
+		default:
+			functions = append(functions, cmd.extractBody(fn, src))
+		}
+
+		return true
+	})
+
+	if configFunc == "" {
+		return nil, errors.New("no s:config() function in plugconf: " + plugConf)
+	}
+
+	return &parsedPlugconf{
+		number:     len(parsedList) + 1,
+		configFunc: configFunc,
+		functions:  functions,
+		loadOn:     loadOn,
+	}, nil
+}
+
+// Inspect return value of s:start_on() function in plugconf
+func (cmd *plugconfCmd) inspectReturnValue(fn *ast.Function) (loadOnType, error) {
+	var loadOn loadOnType
+	ast.Inspect(fn, func(node ast.Node) bool {
+		// Cast to return node (return if it's not a return node)
+		var ret *ast.Return
+		if r, ok := node.(*ast.Return); !ok {
+			return true
+		} else {
+			ret = r
+		}
+
+		// TODO: Parse the argument of :return
+
+		return true
+	})
+	if string(loadOn) == "" {
+		return "", errors.New("can't detect return value of s:")
+	}
+	return loadOn, nil
+}
+
+func (cmd *plugconfCmd) extractBody(fn *ast.Function, src string) string {
+	pos := fn.Pos()
+
+	// TODO: Handle line break
+	endpos := fn.EndFunction.Pos()
+	endfunc := fn.EndFunction.ExArg
+	cmdlen := endfunc.Argpos.Offset - endfunc.Cmdpos.Offset
+	endpos.Offset += cmdlen
+	endpos.Column += cmdlen
+
+	return src[pos.Offset:endpos.Offset]
+}
+
+func (cmd *plugconfCmd) makeBundledPlugConf(parsedList []parsedPlugconf, funcCap int) []byte {
+	functions := make([]string, 0, funcCap)
+	autocommands := make([]string, 0, len(parsedList))
+	for _, p := range parsedList {
+		// TODO: replace only function name node
+		functions = append(functions, strings.Replace(p.configFunc, "s:config", fmt.Sprintf("s:config_%d", p.number), -1))
+		functions = append(functions, p.functions...)
+		autocommands = append(autocommands, fmt.Sprintf("  autocmd %s * call s:config_%d()", string(p.loadOn), p.number))
+	}
+	return []byte(fmt.Sprintf(`%s
+
+augroup volt-bundled-plugconf
+  autocmd!
+  %s
+augroup END
+`, strings.Join(functions, "\n\n"), strings.Join(autocommands, "\n")))
 }
 
 func (*plugconfCmd) doUnbundle(_ []string) error {

--- a/cmd/plugconf.go
+++ b/cmd/plugconf.go
@@ -268,7 +268,7 @@ func (cmd *plugconfCmd) parsePlugConf(plugConf string, parsedList []parsedPlugco
 		}
 
 		switch name {
-		case "s:start_on":
+		case "s:load_on":
 			var err error
 			loadOn, err = cmd.inspectReturnValue(fn)
 			if err != nil {
@@ -295,7 +295,7 @@ func (cmd *plugconfCmd) parsePlugConf(plugConf string, parsedList []parsedPlugco
 	}, nil
 }
 
-// Inspect return value of s:start_on() function in plugconf
+// Inspect return value of s:load_on() function in plugconf
 func (cmd *plugconfCmd) inspectReturnValue(fn *ast.Function) (loadOnType, error) {
 	var loadOn loadOnType
 	ast.Inspect(fn, func(node ast.Node) bool {

--- a/cmd/plugconf.go
+++ b/cmd/plugconf.go
@@ -191,8 +191,9 @@ func (cmd *plugconfCmd) doExport(args []string) error {
 	if merr.ErrorOrNil() != nil {
 		for _, err := range merr.Errors {
 			// Show vim script parse errors
-			logger.Warn(err.Error())
+			logger.Error(err.Error())
 		}
+		return nil
 	}
 	os.Stdout.Write(output)
 	return nil

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -199,7 +199,7 @@ func (cmd *profileCmd) doSet(args []string) error {
 
 	logger.Info("Set active profile to '" + profileName + "'")
 
-	// Rebuild start dir
+	// Rebuild ~/.vim/pack/volt dir
 	err = (&rebuildCmd{}).doRebuild(false)
 	if err != nil {
 		return errors.New("could not rebuild " + pathutil.VimVoltDir() + ": " + err.Error())
@@ -397,7 +397,7 @@ func (cmd *profileCmd) doAdd(args []string) error {
 	}
 
 	if len(enabled) > 0 {
-		// Rebuild start dir
+		// Rebuild ~/.vim/pack/volt dir
 		err = (&rebuildCmd{}).doRebuild(false)
 		if err != nil {
 			return errors.New("could not rebuild " + pathutil.VimVoltDir() + ": " + err.Error())
@@ -446,7 +446,7 @@ func (cmd *profileCmd) doRm(args []string) error {
 	}
 
 	if len(disabled) > 0 {
-		// Rebuild start dir
+		// Rebuild ~/.vim/pack/volt dir
 		err = (&rebuildCmd{}).doRebuild(false)
 		if err != nil {
 			return errors.New("could not rebuild " + pathutil.VimVoltDir() + ": " + err.Error())
@@ -589,7 +589,7 @@ func (cmd *profileCmd) doUse(args []string) error {
 			return err
 		}
 
-		// Rebuild start dir
+		// Rebuild ~/.vim/pack/volt dir
 		err = (&rebuildCmd{}).doRebuild(false)
 		if err != nil {
 			return errors.New("could not rebuild " + pathutil.VimVoltDir() + ": " + err.Error())

--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -317,7 +317,8 @@ func (cmd *rebuildCmd) doRebuild(full bool) error {
 
 		// Generate bundle plugconf content
 		plugconf := plugconfCmd{}
-		content, merr := plugconf.generateBundlePlugconf(reposList)
+		isSystem := true
+		content, merr := plugconf.generateBundlePlugconf(isSystem, reposList)
 		for _, err := range merr.Errors {
 			// Show vim script parse errors
 			logger.Warn(err.Error())

--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -315,7 +315,7 @@ func (cmd *rebuildCmd) doRebuild(full bool) error {
 		cmd.constructBuildInfo(buildInfo, result)
 		copyModified = true
 
-		// Generate bundle plugconf content
+		// Generate bundled plugconf content
 		plugconf := plugconfCmd{}
 		isSystem := true
 		content, merr := plugconf.generateBundlePlugconf(isSystem, reposList)

--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/vim-volt/volt/fileutil"
@@ -19,6 +20,8 @@ import (
 	"github.com/vim-volt/volt/transaction"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/haya14busa/go-vimlparser"
+	"github.com/haya14busa/go-vimlparser/ast"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
@@ -310,10 +313,41 @@ func (cmd *rebuildCmd) doRebuild(full bool) error {
 
 	// Wait copy
 	var copyModified bool
-	copyErr := cmd.waitCopyRepos(copyDone, copyCount, func(result *actionReposResult) {
+	copyErr := cmd.waitCopyRepos(copyDone, copyCount, func(result *actionReposResult) *multierror.Error {
 		// Construct buildInfo from the result
 		cmd.constructBuildInfo(buildInfo, result)
 		copyModified = true
+
+		// Parse plugconfs and make parsed plugconf info
+		var merr *multierror.Error
+		var parsedList []ParsedPlugConf
+		var funcCap int
+		for _, repos := range reposList {
+			var parsed *ParsedPlugConf
+			var err error
+			user := pathutil.UserPlugConfOf(repos.Path)
+			system := pathutil.SystemPlugConfOf(repos.Path)
+			if pathutil.Exists(user) {
+				parsed, err = cmd.parsePlugConf(user, parsedList)
+			} else if pathutil.Exists(system) {
+				parsed, err = cmd.parsePlugConf(system, parsedList)
+			}
+			if err != nil {
+				merr = multierror.Append(merr, err)
+			} else {
+				parsedList = append(parsedList, *parsed)
+				funcCap += len(parsed.functions) + 1 /* +1 for s:config() */
+			}
+		}
+
+		// Write parsed plugconf info to bundled plugconf file
+		content := cmd.makeBundledPlugConf(parsedList, funcCap)
+		err := ioutil.WriteFile(pathutil.BundledPlugConf(), content, 0644)
+		if err != nil {
+			merr = multierror.Append(merr, err)
+		}
+
+		return merr
 	})
 
 	// Wait remove
@@ -339,6 +373,137 @@ func (cmd *rebuildCmd) doRebuild(full bool) error {
 	}
 
 	return nil
+}
+
+type loadOnType string
+
+const (
+	loadOnStart    loadOnType = "VimEnter"
+	loadOnFileType            = "FileType"
+	loadOnExcmd               = "CmdUndefined"
+)
+
+type ParsedPlugConf struct {
+	number     int
+	configFunc string
+	functions  []string
+	loadOn     loadOnType
+}
+
+func (cmd *rebuildCmd) parsePlugConf(plugConf string, parsedList []ParsedPlugConf) (*ParsedPlugConf, error) {
+	bytes, err := ioutil.ReadFile(plugConf)
+	if err != nil {
+		return nil, err
+	}
+	src := string(bytes)
+
+	file, err := vimlparser.ParseFile(strings.NewReader(src), plugConf, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var loadOn loadOnType
+	var configFunc string
+	var functions []string
+	var parseErr error
+
+	// Inspect nodes and get above values from plugconf script
+	ast.Inspect(file, func(node ast.Node) bool {
+		// Cast to function node (return if it's not a function node)
+		var fn *ast.Function
+		if f, ok := node.(*ast.Function); !ok {
+			return true
+		} else {
+			fn = f
+		}
+
+		// Get function name
+		var name string
+		if ident, ok := fn.Name.(*ast.Ident); !ok {
+			return true
+		} else {
+			name = ident.Name
+		}
+
+		switch name {
+		case "s:start_on":
+			var err error
+			loadOn, err = cmd.inspectReturnValue(fn)
+			if err != nil {
+				parseErr = err
+			}
+		case "s:config":
+			configFunc = cmd.extractBody(fn, src)
+		default:
+			functions = append(functions, cmd.extractBody(fn, src))
+		}
+
+		return true
+	})
+
+	if configFunc == "" {
+		return nil, errors.New("no s:config() function in plugconf: " + plugConf)
+	}
+
+	return &ParsedPlugConf{
+		number:     len(parsedList) + 1,
+		configFunc: configFunc,
+		functions:  functions,
+		loadOn:     loadOn,
+	}, nil
+}
+
+// Inspect return value of s:start_on() function in plugconf
+func (cmd *rebuildCmd) inspectReturnValue(fn *ast.Function) (loadOnType, error) {
+	var loadOn loadOnType
+	ast.Inspect(fn, func(node ast.Node) bool {
+		// Cast to return node (return if it's not a return node)
+		var ret *ast.Return
+		if r, ok := node.(*ast.Return); !ok {
+			return true
+		} else {
+			ret = r
+		}
+
+		// TODO: Parse the argument of :return
+
+		return true
+	})
+	if string(loadOn) == "" {
+		return "", errors.New("can't detect return value of s:")
+	}
+	return loadOn, nil
+}
+
+func (cmd *rebuildCmd) extractBody(fn *ast.Function, src string) string {
+	pos := fn.Pos()
+
+	// TODO: Handle line break
+	endpos := fn.EndFunction.Pos()
+	endfunc := fn.EndFunction.ExArg
+	cmdlen := endfunc.Argpos.Offset - endfunc.Cmdpos.Offset
+	endpos.Offset += cmdlen
+	endpos.Column += cmdlen
+
+	return src[pos.Offset:endpos.Offset]
+}
+
+func (cmd *rebuildCmd) makeBundledPlugConf(parsedList []ParsedPlugConf, funcCap int) []byte {
+	functions := make([]string, 0, funcCap)
+	autocommands := make([]string, 0, len(parsedList))
+	for _, p := range parsedList {
+		// TODO: replace only function name node
+		functions = append(functions, strings.Replace(p.configFunc, "s:config", fmt.Sprintf("s:config_%d", p.number), -1))
+		functions = append(functions, p.functions...)
+		autocommands = append(autocommands, fmt.Sprintf("  autocmd %s * call s:config_%d()", string(p.loadOn), p.number))
+	}
+	return []byte(fmt.Sprintf(`%s
+
+augroup volt-bundled-plugconf
+  autocmd!
+  %s
+augroup END
+`, strings.Join(functions, "\n\n"), strings.Join(autocommands, "\n")))
 }
 
 func (cmd *rebuildCmd) installRCFile(profileName, srcRCFileName, dst string, install bool) error {
@@ -475,7 +640,7 @@ func (cmd *rebuildCmd) removeReposList(buildInfoRepos reposList, lockReposList l
 	return removeDone, len(removeList)
 }
 
-func (*rebuildCmd) waitCopyRepos(copyDone chan actionReposResult, copyCount int, callback func(*actionReposResult)) *multierror.Error {
+func (*rebuildCmd) waitCopyRepos(copyDone chan actionReposResult, copyCount int, callback func(*actionReposResult) *multierror.Error) *multierror.Error {
 	var merr *multierror.Error
 	for i := 0; i < copyCount; i++ {
 		result := <-copyDone
@@ -487,7 +652,12 @@ func (*rebuildCmd) waitCopyRepos(copyDone chan actionReposResult, copyCount int,
 						"': "+result.err.Error()))
 		} else {
 			logger.Info("Installing " + string(result.repos.Type) + " repository " + result.repos.Path + " ... Done.")
-			callback(&result)
+			merr2 := callback(&result)
+			if merr2 != nil {
+				for _, err := range merr2.Errors {
+					merr = multierror.Append(merr, err)
+				}
+			}
 		}
 	}
 	return merr

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -64,10 +64,10 @@ func Rm(args []string) int {
 		return 11
 	}
 
-	// Rebuild start dir
+	// Rebuild opt dir
 	err = (&rebuildCmd{}).doRebuild(false)
 	if err != nil {
-		logger.Error("Could not rebuild " + pathutil.VimVoltStartDir() + ": " + err.Error())
+		logger.Error("could not rebuild " + pathutil.VimVoltDir() + ": " + err.Error())
 		return 12
 	}
 

--- a/pathutil/pathutil.go
+++ b/pathutil/pathutil.go
@@ -105,7 +105,7 @@ func RCFileOf(profileName, filename string) string {
 
 func PackReposPathOf(reposPath string) string {
 	path := strings.NewReplacer("_", "__", "/", "_").Replace(reposPath)
-	return filepath.Join(VimVoltStartDir(), path)
+	return filepath.Join(VimVoltOptDir(), path)
 }
 
 func LockJSON() string {
@@ -130,6 +130,10 @@ func VimDir() string {
 
 func VimVoltDir() string {
 	return filepath.Join(VimDir(), "pack", "volt")
+}
+
+func VimVoltOptDir() string {
+	return filepath.Join(VimDir(), "pack", "volt", "opt")
 }
 
 func VimVoltStartDir() string {

--- a/pathutil/pathutil.go
+++ b/pathutil/pathutil.go
@@ -140,6 +140,10 @@ func BuildInfoJSON() string {
 	return filepath.Join(VimVoltDir(), "build-info.json")
 }
 
+func BundledPlugConf() string {
+	return filepath.Join(VimVoltStartDir(), "system", "plugin", "bundled_plugconf.vim")
+}
+
 func LookUpVimrcOrGvimrc() []string {
 	return append(LookUpVimrc(), LookUpGvimrc()...)
 }


### PR DESCRIPTION
Implement configuration per plugin (plugconf).

- [x] `volt plugconf export`
- [x] Bundle functions and install under `~/.vim/pack/volt/start/system/plugin/bundled_plugconf.vim`
  - if `s:load_on()` returns `start`, load plugin configuration by `autocmd VimEnter * call s:config_{number}()`
  - if `s:load_on()` returns `filetype={pattern}`, load plugin configuration by `autocmd FileType {pattern} call s:config_{number}()`
  - if `s:load_on()` returns `excmd={pattern}`, load plugin configuration by `autocmd CmdUndefined {pattern} call s:config_{number}()`
- [x] Install plugins under `~/.vim/pack/volt/opt/`, load them from `~/.vim/pack/volt/start/system/plugin/bundled_plugconf.vim` by `:packadd`
- [x] Sort list of `:packadd` by dependency order (move dependencies to first)