### PR TITLE
Fix compile error: Println arg redundant newline

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -24,7 +24,7 @@ func init() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	fs.SetOutput(os.Stdout)
 	fs.Usage = func() {
-		fmt.Println(`
+		fmt.Print(`
 Usage
   volt add {from} {local repository}
 
@@ -39,8 +39,7 @@ Description
     If {local repository} does not contain "/", it is treated as
     "localhost/local/{local repository}" repository.
     If {local repository} contains "/", it is treated as
-    same format as "volt get" (see "volt get -help").
-`)
+    same format as "volt get" (see "volt get -help").` + "\n\n")
 		//fmt.Println("Options")
 		//fs.PrintDefaults()
 		fmt.Println()

--- a/cmd/disable.go
+++ b/cmd/disable.go
@@ -20,7 +20,7 @@ func init() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	fs.SetOutput(os.Stdout)
 	fs.Usage = func() {
-		fmt.Println(`
+		fmt.Print(`
 Usage
   volt disable {repository} [{repository2} ...]
 
@@ -29,8 +29,7 @@ Quick example
 
 Description
   This is shortcut of:
-  volt profile rm {current profile} {repository} [{repository2} ...]
-`)
+  volt profile rm {current profile} {repository} [{repository2} ...]` + "\n\n")
 		//fmt.Println("Options")
 		//fs.PrintDefaults()
 		fmt.Println()

--- a/cmd/enable.go
+++ b/cmd/enable.go
@@ -20,7 +20,7 @@ func init() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	fs.SetOutput(os.Stdout)
 	fs.Usage = func() {
-		fmt.Println(`
+		fmt.Print(`
 Usage
   volt enable {repository} [{repository2} ...]
 
@@ -29,8 +29,7 @@ Quick example
 
 Description
   This is shortcut of:
-  volt profile add {current profile} {repository} [{repository2} ...]
-`)
+  volt profile add {current profile} {repository} [{repository2} ...]` + "\n\n")
 		//fmt.Println("Options")
 		//fs.PrintDefaults()
 		fmt.Println()

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -32,7 +32,7 @@ func Help(args []string) int {
 }
 
 func showHelp() {
-	fmt.Println(`
+	fmt.Print(`
 Usage
   volt COMMAND ARGS
 
@@ -103,6 +103,5 @@ Command
     Rebuild ~/.vim/pack/volt/ directory
 
   version
-    Show volt command version
-`)
+    Show volt command version` + "\n\n")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -18,7 +18,7 @@ func init() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	fs.SetOutput(os.Stdout)
 	fs.Usage = func() {
-		fmt.Println(`
+		fmt.Print(`
 Usage
   volt list
 
@@ -27,8 +27,7 @@ Quick example
 
 Description
   This is shortcut of:
-  volt profile show {current profile}
-`)
+  volt profile show {current profile}` + "\n\n")
 		//fmt.Println("Options")
 		//fs.PrintDefaults()
 		fmt.Println()

--- a/cmd/plugconf.go
+++ b/cmd/plugconf.go
@@ -31,7 +31,7 @@ func init() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	fs.SetOutput(os.Stdout)
 	fs.Usage = func() {
-		fmt.Println(`
+		fmt.Print(`
 Usage
   plugconf list [-a]
     List all user plugconfs. If -a option was given, list also system plugconfs.
@@ -75,8 +75,7 @@ Quick example
 
   $ volt plugconf bundle >bundle-plugconf.vim
   $ vim bundle-plugconf.vim  # edit config
-  $ volt plugconf unbundle <bundle-plugconf.vim
-`)
+  $ volt plugconf unbundle <bundle-plugconf.vim` + "\n\n")
 		fs.PrintDefaults()
 		fmt.Println()
 		plugconfFlags.helped = true

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -38,7 +38,7 @@ func init() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	fs.SetOutput(os.Stdout)
 	fs.Usage = func() {
-		fmt.Println(`
+		fmt.Print(`
 Usage
   profile [get]
     Get current profile name.
@@ -89,8 +89,7 @@ Quick example
   $ volt disable tyru/open-browser.vim # if profile name is current active profile, you can also use "volt disable" command instead
   $ volt profile add foo tyru/caw.vim # will enable loading tyru/caw.vim plugin on profile "foo"
   $ volt enable tyru/open-browser.vim
-  $ volt profile destroy foo # will delete profile "foo"
-`)
+  $ volt profile destroy foo # will delete profile "foo"` + "\n\n")
 		profileFlags.helped = true
 	}
 

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -24,7 +24,7 @@ func init() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	fs.SetOutput(os.Stdout)
 	fs.Usage = func() {
-		fmt.Println(`
+		fmt.Print(`
 Usage
   volt query [-help] [-j] [-l] [{repository} ...]
 
@@ -36,8 +36,7 @@ Quick example
 Description
   Output queried vim plugins info ("version" and "trx_id"). "version" is vim plugin's locked version. "trx_id" is transaction ID (transaction is volt's internal operation unit). The ID is incremented when plugins are installed or uninstalled by "volt add", "volt get", "volt rm".
 
-  {repository} is treated as same format as "volt get" (see "volt get -help").
-`)
+  {repository} is treated as same format as "volt get" (see "volt get -help").` + "\n\n")
 		fmt.Println("Options")
 		fs.PrintDefaults()
 		fmt.Println()

--- a/cmd/rebuild.go
+++ b/cmd/rebuild.go
@@ -35,7 +35,7 @@ func init() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	fs.SetOutput(os.Stdout)
 	fs.Usage = func() {
-		fmt.Println(`
+		fmt.Print(`
 Usage
   volt rebuild [-help] [-full]
 
@@ -53,8 +53,7 @@ Description
   ~/.vim/pack/volt/build-info.json is a file which holds the information that what vim plugins are installed in ~/.vim/pack/volt/ and its type (git repository, static repository, or system repository), its version. A user normally doesn't need to know the contents of build-info.json .
 
   If -full option was given, remove all directories in ~/.vim/pack/volt/start/ and ~/.vim/pack/volt/opt/ , and copy repositories' files into above vim directories.
-  Otherwise, it will perform smart rebuild: copy / remove only changed repositories' files.
-`)
+  Otherwise, it will perform smart rebuild: copy / remove only changed repositories' files.` + "\n\n")
 		fmt.Println("Options")
 		fs.PrintDefaults()
 		fmt.Println()

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -24,7 +24,7 @@ func init() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	fs.SetOutput(os.Stdout)
 	fs.Usage = func() {
-		fmt.Println(`
+		fmt.Print(`
 Usage
   volt rm [-help] {repository} [{repository2} ...]
 
@@ -34,8 +34,7 @@ Quick example
 Description
   Uninstall vim plugin of {repository} on every profile.
 
-  {repository} is treated as same format as "volt get" (see "volt get -help").
-`)
+  {repository} is treated as same format as "volt get" (see "volt get -help").` + "\n\n")
 		//fmt.Println("Options")
 		//fs.PrintDefaults()
 		fmt.Println()


### PR DESCRIPTION
## Compile error

```
cmd/add.go:27: Println arg list ends with redundant newline
```