### PR TITLE
Unite user/system plugconf path

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,14 +138,14 @@ $ tree -L 1 ~/volt/
 └ ─ ─  repos
 ```
 
-See [volt directory](https://github.com/tyru/dotfiles/tree/75a37b4a640a5cffecf34d2a52406d0f53ee6f09/dotfiles/volt) in [tyru/dotfiles](https://github.com/tyru/dotfiles/) repository for example.
+See [volt directory](https://github.com/tyru/dotfiles/tree/36456c73e66898c8a725e2043ff0ffcba941ebf4/dotfiles/volt) in [tyru/dotfiles](https://github.com/tyru/dotfiles/) repository for example.
 
 ### Configuration per plugin ("Plugconf" feature)
 
 You can write plugin configuration in "plugconf" file.
 The files are placed at:
 
-* `$VOLTPATH/plugconf/user/<repository>.vim`
+* `$VOLTPATH/plugconf/<repository>.vim`
 
 For example, [tyru/open-browser-github.vim](https://github.com/tyru/open-browser-github.vim) configuration is `$VOLTPATH/plugconf/user/github.com/tyru/open-browser.vim.vim` because "github.com/tyru/open-browser-github.vim" is the repository URL.
 
@@ -164,7 +164,7 @@ Some special functions can be defined in plugconf file:
     * The specified plugins by this function are loaded before the plugin of plugconf
     * e.g.: `["github.com/tyru/open-browser.vim"]`
 
-However, you can also define global functions in plugconf (see [tyru/nextfile.vim example](https://github.com/tyru/dotfiles/blob/master/dotfiles/volt/plugconf/user/github.com/tyru/nextfile.vim.vim)).
+However, you can also define global functions in plugconf (see [tyru/nextfile.vim example](https://github.com/tyru/dotfiles/blob/36456c73e66898c8a725e2043ff0ffcba941ebf4/dotfiles/volt/plugconf/github.com/tyru/nextfile.vim.vim)).
 
 An example config of [tyru/open-browser-github.vim](https://github.com/tyru/open-browser-github.vim):
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -43,10 +43,10 @@ Quick example
   $ volt get -v tyru/caw.vim # will output verbose git-clone(1) output
 
 Description
-  Install vim plugin from {repository}, or upgrade vim plugin of {repository} list on current active profile. And fetch system plugconf files from:
+  Install vim plugin from {repository}, or upgrade vim plugin of {repository} list on current active profile. And fetch skeleton plugconf from:
     https://github.com/vim-volt/plugconf-templates
   and install it to:
-    $VOLTPATH/plugconf/system/{repository}.vim
+    $VOLTPATH/plugconf/{repository}.vim
 
   {repository}'s format is one of the followings:
 
@@ -398,7 +398,7 @@ func (*getCmd) installPlugConf(reposPath string) error {
 		return err
 	}
 
-	fn := pathutil.SystemPlugconfOf(reposPath)
+	fn := pathutil.PlugconfOf(reposPath)
 	os.MkdirAll(filepath.Dir(fn), 0755)
 
 	err = ioutil.WriteFile(fn, bytes, 0644)

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -38,11 +38,11 @@ Usage
 
 Command
   get [-l] [-u] [-v] [{repository} ...]
-    Install / Upgrade vim plugin, and system plugconf files from
+    Install / Upgrade vim plugin, and fetch plugconf from
     https://github.com/vim-volt/plugconf-templates
 
   rm {repository} [{repository2} ...]
-    Uninstall vim plugin and system plugconf files
+    Uninstall vim plugin and plugconf files
 
   add {from} {repository}
     Add local {from} repository as {repository} to lock.json
@@ -90,8 +90,8 @@ Command
   profile use [-current | {name}] gvimrc [true | false]
     Set vimrc / gvimrc flag to true or false.
 
-  plugconf list [-a]
-    List all user plugconfs. If -a option was given, list also system plugconfs.
+  plugconf list
+    List all user plugconfs.
 
   plugconf export
     Outputs bundled plugconf to stdout.

--- a/cmd/plugconf.go
+++ b/cmd/plugconf.go
@@ -43,13 +43,13 @@ func init() {
 	fs.Usage = func() {
 		fmt.Print(`
 Usage
-  plugconf list [-a]
-    List all user plugconfs. If -a option was given, list also system plugconfs.
+  plugconf list
+    List all plugconfs.
 
   plugconf export
     Outputs bundled plugconf to stdout.
     Note that the output differs a bit from the file written by "volt rebuild"
-    (~/.vim/pack/volt/opt/system/plugin/bundled_plugconf.vim).
+    (~/.vim/pack/volt/start/system/plugin/bundled_plugconf.vim).
     Some functions are removed in the file because it is unnecessary for Vim.
     But this command shows them because this command must export all in plugconfs.
 
@@ -138,11 +138,6 @@ func (cmd *plugconfCmd) parseArgs(args []string) ([]string, error) {
 }
 
 func (*plugconfCmd) doList(args []string) error {
-	var showSystem bool
-	if len(args) > 0 && args[0] == "-a" {
-		showSystem = true
-	}
-
 	// Read lock.json
 	lockJSON, err := lockjson.Read()
 	if err != nil {
@@ -151,13 +146,9 @@ func (*plugconfCmd) doList(args []string) error {
 
 	for i := range lockJSON.Repos {
 		repos := &lockJSON.Repos[i]
-		user := pathutil.UserPlugconfOf(repos.Path)
-		system := pathutil.SystemPlugconfOf(repos.Path)
-		if pathutil.Exists(user) {
-			fmt.Println(user)
-		}
-		if showSystem && pathutil.Exists(system) {
-			fmt.Println(system)
+		path := pathutil.PlugconfOf(repos.Path)
+		if pathutil.Exists(path) {
+			fmt.Println(path)
 		}
 	}
 
@@ -209,12 +200,9 @@ func (cmd *plugconfCmd) generateBundlePlugconf(exportAll bool, reposList []lockj
 	for _, repos := range reposList {
 		var parsed *parsedPlugconf
 		var err error
-		user := pathutil.UserPlugconfOf(repos.Path)
-		system := pathutil.SystemPlugconfOf(repos.Path)
-		if pathutil.Exists(user) {
-			parsed, err = cmd.parsePlugConf(user, reposID, repos.Path)
-		} else if pathutil.Exists(system) {
-			parsed, err = cmd.parsePlugConf(system, reposID, repos.Path)
+		path := pathutil.PlugconfOf(repos.Path)
+		if pathutil.Exists(path) {
+			parsed, err = cmd.parsePlugConf(path, reposID, repos.Path)
 		} else {
 			continue
 		}

--- a/pathutil/pathutil.go
+++ b/pathutil/pathutil.go
@@ -71,24 +71,11 @@ func CloneURLOf(repos string) string {
 	return "https://" + filepath.ToSlash(repos)
 }
 
-func UserPlugconfOf(reposPath string) string {
-	return plugconfOf(reposPath, false)
-}
-
-func SystemPlugconfOf(reposPath string) string {
-	return plugconfOf(reposPath, true)
-}
-
-func plugconfOf(reposPath string, system bool) string {
+func PlugconfOf(reposPath string) string {
 	filenameList := strings.Split(filepath.ToSlash(reposPath+".vim"), "/")
-	paths := make([]string, 0, len(filenameList)+3)
+	paths := make([]string, 0, len(filenameList)+2)
 	paths = append(paths, VoltPath())
 	paths = append(paths, "plugconf")
-	if system {
-		paths = append(paths, "system")
-	} else {
-		paths = append(paths, "user")
-	}
 	paths = append(paths, filenameList...)
 	return filepath.Join(paths...)
 }


### PR DESCRIPTION
## Changes

* Unite user/system plugconf path
    * path: $VOLTPATH/plugconf/<repos>.vim
* Remove '-a' option from 'volt plugconf list'
* Add '-p' option to 'volt rm' which removes also plugconf file

## Migration

The plugconf path was changed:

* Before
    * $VOLTPATH/plugconf/user/<repos>.vim
    * $VOLTPATH/plugconf/system/<repos>.vim
* After
    * $VOLTPATH/plugconf/<repos>.vim

Users can migrate existing plugconf files like:

```
$ mv ~/volt/plugconf/user/* ~/volt/plugconf/
$ rmdir ~/volt/plugconf/user
```

Currently no plugconf files are placed at https://github.com/vim-volt/plugconf-templates ,
so it's safe to ignore `~/volt/plugconf/system/*`.