### PR TITLE
Introduce AppVeyor CI (and fix failed tests on Windows)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ go:
   - tip
 
 script:
-  # Ignore ./it and ./internal/testutil
-  - go vet -v $(go list -f '{{ .ImportPath }}' github.com/vim-volt/volt/... | grep -v -E '/volt/(it|internal/testutil)$')
+  - go vet -v ./...
   - make test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 NAME := volt
-SRC := $(shell find . -type d -name 'vendor' -prune -o -type d -name 'it' -prune -o -type f -name '*.go' -print)
+SRC := $(shell find . -type d -name 'vendor' -prune -o -type f -name '*.go' -print)
 VERSION := $(shell sed -n -E 's/var voltVersion string = "([^"]+)"/\1/p' cmd/version.go)
 RELEASE_LDFLAGS := -extldflags '-static'
 RELEASE_OS := linux windows darwin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,34 @@
+version: '{build}'
+clone_depth: 1
+
+platform: x64
+
+clone_folder: c:\gopath\src\github.com\vim-volt\volt
+
+environment:
+  GOPATH: c:\gopath
+  VIM_URL: http://vim-jp.org/redirects/koron/vim-kaoriya/vim80/oldest/win64/
+
+install:
+  - echo %PATH%
+  - echo %GOPATH%
+  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
+  - go version
+  - go env
+  # Install vim
+  # https://github.com/vim-jp/vital.vim/blob/master/appveyor.yml
+  - ps: |
+      $zip = $Env:APPVEYOR_BUILD_FOLDER + '\vim.zip'
+      $vim = $Env:APPVEYOR_BUILD_FOLDER + '\vim\'
+      $redirect = Invoke-WebRequest -URI $Env:VIM_URL
+      (New-Object Net.WebClient).DownloadFile($redirect.Links[0].href, $zip)
+      [Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem') > $null
+      [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $vim)
+      $Env:VOLT_VIM = $vim + (Get-ChildItem $vim).Name + '\vim.exe'
+
+test_script:
+  - go build -o c:\gopath\src\github.com\vim-volt\volt\bin\volt.exe
+  - go test -v -race -parallel 3 ./...
+
+build: off
+deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,13 @@ clone_folder: c:\gopath\src\github.com\vim-volt\volt
 
 environment:
   GOPATH: c:\gopath
+  MYGODIR: C:\go19
   VIM_URL: http://vim-jp.org/redirects/koron/vim-kaoriya/vim80/oldest/win64/
 
 install:
+  - set PATH=%GOPATH%\bin;%MYGODIR%\bin;%PATH%
   - echo %PATH%
   - echo %GOPATH%
-  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
   - go version
   - go env
   # Install vim

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,4 +1,4 @@
-package it
+package cmd
 
 import (
 	"path/filepath"

--- a/cmd/profile_test.go
+++ b/cmd/profile_test.go
@@ -1,4 +1,4 @@
-package it
+package cmd
 
 import (
 	"testing"

--- a/cmd/rm_test.go
+++ b/cmd/rm_test.go
@@ -1,4 +1,4 @@
-package it
+package cmd
 
 import (
 	"os"

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -11,10 +11,21 @@ import (
 	"testing"
 )
 
-const voltCommand = "../bin/volt"
+var voltCommand string
+
+func init() {
+	const thisFile = "internal/testutil/testutil.go"
+	_, fn, _, _ := runtime.Caller(0)
+	dir := strings.TrimSuffix(fn, thisFile)
+	if runtime.GOOS == "windows" {
+		voltCommand = filepath.Join(dir, "bin", "volt.exe")
+	} else {
+		voltCommand = filepath.Join(dir, "bin", "volt")
+	}
+}
 
 func SetUpEnv(t *testing.T) {
-	tempDir, err := ioutil.TempDir("/tmp", "volt-test-")
+	tempDir, err := ioutil.TempDir("", "volt-test-")
 	if err != nil {
 		t.Fatal("failed to create temp dir")
 	}

--- a/pathutil/pathutil.go
+++ b/pathutil/pathutil.go
@@ -107,6 +107,24 @@ func TempPath() string {
 	return filepath.Join(VoltPath(), "tmp")
 }
 
+func VimExecutable() (string, error) {
+	var vim string
+	if vim = os.Getenv("VOLT_VIM"); vim != "" {
+		return vim, nil
+	}
+	exeName := "vim"
+	if runtime.GOOS == "windows" {
+		exeName = "vim.exe"
+	}
+	sep := string([]rune{os.PathListSeparator})
+	for _, path := range strings.Split(os.Getenv("PATH"), sep) {
+		if vim = filepath.Join(path, exeName); Exists(vim) {
+			return vim, nil
+		}
+	}
+	return "", errors.New("vim not found in PATH")
+}
+
 func VimDir() string {
 	if runtime.GOOS == "windows" {
 		return filepath.Join(HomeDir(), "vimfiles")


### PR DESCRIPTION
Fix #92 

* Introduce AppVeyor
    * Fix test codes for windows
* Windows support
    * Search vim executable: use `$VOLT_VIM` if defined, or find vim executable from PATH