### PR TITLE
Fix: `volt get <repos>` panicked on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 language: go
 
-go:
-  - 1.9.1
-  - tip
+matrix:
+  include:
+    - os: linux
+      go: 1.9.1
+    - os: linux
+      go: tip
+    - os: osx
+      osx_image: xcode8.3
+      go: 1.9.1
+    - os: osx
+      osx_image: xcode8.3
+      go: tip
 
 script:
   - go vet -v ./...

--- a/fileutil/copyfile_generic.go
+++ b/fileutil/copyfile_generic.go
@@ -1,4 +1,4 @@
-// +build !darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+// +build !linux
 
 package fileutil
 

--- a/fileutil/copyfile_linux.go
+++ b/fileutil/copyfile_linux.go
@@ -1,4 +1,4 @@
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+// +build linux
 
 package fileutil
 


### PR DESCRIPTION
Fix #128

* [Travis] Introduce macOS test
* Fix: `volt get <repos>` panicked on macOS