### PR TITLE
"volt self-upgrade" fails to upgrade

### DIFF
--- a/cmd/self_upgrade.go
+++ b/cmd/self_upgrade.go
@@ -166,15 +166,14 @@ func (cmd *selfUpgradeCmd) doSelfUpgrade(flags *selfUpgradeFlagsType, latestURL 
 	if err != nil {
 		return err
 	}
-	{
-		latestFile, err := os.OpenFile(voltExe+".latest", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0777)
-		if err != nil {
-			return err
-		}
-		defer latestFile.Close()
-		if err = cmd.download(latestFile, release); err != nil {
-			return err
-		}
+	latestFile, err := os.OpenFile(voltExe+".latest", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0777)
+	if err != nil {
+		return err
+	}
+	err = cmd.download(latestFile, release)
+	latestFile.Close()
+	if err != nil {
+		return err
 	}
 
 	// Rename dir/volt[.exe] to dir/volt[.exe].old


### PR DESCRIPTION
```
% volt self-upgrade
[INFO] Found update: v0.1.4-alpha -> v0.2.1
[ERROR] Failed to self-upgrade: fork/exec /home/thinca/.go/bin/volt: text file busy
```

P.S.
* Thanks @thinca for report on vim-jp slack.
* Thanks @mattn for suggesting the code.