### PR TITLE
Load ftdetect files on start

### DIFF
--- a/cmd/builder/symlink.go
+++ b/cmd/builder/symlink.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/src-d/go-git.v4"
 
 	"github.com/vim-volt/volt/cmd/buildinfo"
+	"github.com/vim-volt/volt/fileutil"
 	"github.com/vim-volt/volt/gitutil"
 	"github.com/vim-volt/volt/lockjson"
 	"github.com/vim-volt/volt/logger"
@@ -188,7 +189,8 @@ func (builder *symlinkBuilder) linkFTDFiles(src string) error {
 		}
 		if err := filepath.Walk(srcFtdPath, func(path string, info os.FileInfo, err error) error {
 			if srcFtdPath != path {
-				if err := builder.symlink(path, filepath.Join(dstFtdPath, info.Name())); err != nil {
+				buf := make([]byte, 32*1024)
+				if err := fileutil.TryLinkFile(path, filepath.Join(dstFtdPath, info.Name()), buf, info.Mode()); err != nil {
 					return errors.New("could not create " + filepath.Join(dstFtdPath, info.Name()))
 				}
 			}

--- a/pathutil/pathutil.go
+++ b/pathutil/pathutil.go
@@ -160,6 +160,10 @@ func BundledPlugConf() string {
 	return filepath.Join(VimVoltStartDir(), "system", "plugin", "bundled_plugconf.vim")
 }
 
+func VimVoltFtDetectDir() string {
+	return filepath.Join(VimVoltStartDir(), "system", "ftdetect")
+}
+
 func LookUpVimrcOrGvimrc() []string {
 	return append(LookUpVimrc(), LookUpGvimrc()...)
 }

--- a/plugconf/plugconf.go
+++ b/plugconf/plugconf.go
@@ -234,6 +234,11 @@ func makeBundledPlugconf(reposList []lockjson.Repos, plugconf map[string]*Plugco
 		}
 		if loadOn == string(loadOnStart) {
 			loadCmds = append(loadCmds, "  "+invokedCmd)
+		} else if loadOn == string(loadOnFileType) {
+			for i := range patterns {
+				autocmd := fmt.Sprintf("  autocmd %s %s %s | if(!exists('b:did_autocmd')) | let b:did_autocmd=1 | set filetype=%[2]s | endif", loadOn, patterns[i], invokedCmd)
+				loadCmds = append(loadCmds, autocmd)
+			}
 		} else {
 			for i := range patterns {
 				autocmd := fmt.Sprintf("  autocmd %s %s %s", loadOn, patterns[i], invokedCmd)


### PR DESCRIPTION
[posva/vim-vue](https://github.com/posva/vim-vue)のような独自のftdetectを持ったプラグインの遅延読み込み時に手動でfiletypeのセットと対象ファイルの再読み込みが必要だったので、各プラグインのftdetectを`.vim/pack/volt/start/system/ftdetect`以下にコピーして対象ファイルの読込だけでうまく動くようにしてみました。