### PR TITLE
[AppVeyor] Fix go version mismatch

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,11 +7,11 @@ clone_folder: c:\gopath\src\github.com\vim-volt\volt
 
 environment:
   GOPATH: c:\gopath
-  MYGODIR: C:\go19
+  GOROOT: C:\go19
   VIM_URL: http://vim-jp.org/redirects/koron/vim-kaoriya/vim80/oldest/win64/
 
 install:
-  - set PATH=%GOPATH%\bin;%MYGODIR%\bin;%PATH%
+  - set PATH=%GOPATH%\bin;%GOROOT%\bin;%PATH%
   - echo %PATH%
   - echo %GOPATH%
   - go version


### PR DESCRIPTION
#201 was [failed](https://ci.appveyor.com/project/vim-volt/volt/build/391) because go1.9 commands are not always used.
Setting `GOROOT` should fix this.