### PR TITLE
Fix newline

### DIFF
--- a/plugconf/plugconf.go
+++ b/plugconf/plugconf.go
@@ -685,12 +685,14 @@ endfunction
 	}
 
 	if vimrcPath != "" || gvimrcPath != "" {
-		buf.WriteString("\n\n")
+		buf.WriteString("\n")
 		if vimrcPath != "" {
+			buf.WriteString("\n")
 			vimrcPath = strings.Replace(vimrcPath, "'", "''", -1)
 			buf.WriteString("let $MYVIMRC = '" + vimrcPath + "'")
 		}
 		if gvimrcPath != "" {
+			buf.WriteString("\n")
 			gvimrcPath = strings.Replace(gvimrcPath, "'", "''", -1)
 			buf.WriteString("let $MYGVIMRC = '" + gvimrcPath + "'")
 		}


### PR DESCRIPTION
Fix newline of bundled_plugconf.vim.
(`vimfiles/pack/volt/start/system/plugin/bundled_plugconf.vim`)

 * before (eff2f161000b747ca3a2020989e2a4861846dd0e)

```
...
augroup END

let $MYVIMRC = 'C:\Users\xxx\volt\rc\default\vimrc.vim'let $MYGVIMRC = 'C:\Users\xxx\volt\rc\default\gvimrc.vim'
```

 * after (409cd939f8413cd427c5cd9e40e99b03409854a8)

```
...
augroup END

let $MYVIMRC = 'C:\Users\xxx\volt\rc\default\vimrc.vim'
let $MYGVIMRC = 'C:\Users\xxx\volt\rc\default\gvimrc.vim'
```
--
