### PR TITLE
Cleanup tmp dirs after test

### DIFF
--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -2,7 +2,6 @@ package testutil
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -12,6 +11,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/vim-volt/volt/config"
 	"github.com/vim-volt/volt/fileutil"
@@ -55,6 +56,13 @@ func SetUpEnv(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to set %s", env)
 		}
+	}
+}
+
+func CleanUpEnv(t *testing.T) {
+	for _, env := range []string{"VOLTPATH", "HOME"} {
+		parent, _ := filepath.Split(os.Getenv(env))
+		os.RemoveAll(parent)
 	}
 }
 
@@ -141,6 +149,7 @@ func SetUpRepos(t *testing.T, testdataName string, rType lockjson.ReposType, rep
 					t.Fatalf("failed to set VOLTPATH: %s", err)
 				}
 				defer os.Setenv("HOME", home)
+				defer os.RemoveAll(home)
 				if err := os.Setenv("VOLTPATH", tmpVoltpath); err != nil {
 					t.Fatal("failed to set VOLTPATH")
 				}

--- a/subcmd/build_test.go
+++ b/subcmd/build_test.go
@@ -69,6 +69,7 @@ func TestVoltBuildT1ProfileVimrcGvimrcExists(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installProfileRC(t, "default", "vimrc-nomagic.vim", pathutil.ProfileVimrc)
 	installProfileRC(t, "default", "gvimrc-nomagic.vim", pathutil.ProfileGvimrc)
@@ -93,6 +94,7 @@ func TestVoltBuildT1ProfileVimrcExists(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installProfileRC(t, "default", "vimrc-nomagic.vim", pathutil.ProfileVimrc)
 
@@ -116,6 +118,7 @@ func TestVoltBuildT1ProfileGvimrcExists(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installProfileRC(t, "default", "gvimrc-nomagic.vim", pathutil.ProfileGvimrc)
 
@@ -139,6 +142,7 @@ func TestVoltBuildT2UserVimrcGvimrcExists(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installVimRC(t, "vimrc-nomagic.vim", pathutil.Vimrc)
 	installVimRC(t, "gvimrc-nomagic.vim", pathutil.Gvimrc)
@@ -163,6 +167,7 @@ func TestVoltBuildT2UserVimrcExists(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installVimRC(t, "vimrc-nomagic.vim", pathutil.Vimrc)
 
@@ -187,6 +192,7 @@ func TestErrVoltBuildT2CannotOverwriteUserVimrc(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installProfileRC(t, "default", "vimrc-nomagic.vim", pathutil.ProfileVimrc)
 	installVimRC(t, "vimrc-nomagic.vim", pathutil.Vimrc)
@@ -212,6 +218,7 @@ func TestErrVoltBuildT2CannotOverwriteUserGvimrc(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installProfileRC(t, "default", "gvimrc-nomagic.vim", pathutil.ProfileGvimrc)
 	installVimRC(t, "gvimrc-nomagic.vim", pathutil.Gvimrc)
@@ -237,6 +244,7 @@ func TestErrVoltBuildT2DontInstallVimrc(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installProfileRC(t, "default", "vimrc-nomagic.vim", pathutil.ProfileVimrc)
 	installProfileRC(t, "default", "gvimrc-nomagic.vim", pathutil.ProfileGvimrc)
@@ -263,6 +271,7 @@ func TestErrVoltBuildT2DontInstallGvimrc(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installProfileRC(t, "default", "vimrc-nomagic.vim", pathutil.ProfileVimrc)
 	installProfileRC(t, "default", "gvimrc-nomagic.vim", pathutil.ProfileGvimrc)
@@ -289,6 +298,7 @@ func TestVoltBuildT2CanInstallUserVimrc(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installProfileRC(t, "default", "vimrc-nomagic.vim", pathutil.ProfileVimrc)
 	installVimRC(t, "gvimrc-nomagic.vim", pathutil.Gvimrc)
@@ -314,6 +324,7 @@ func TestVoltBuildT3OverwriteUserVimrcGvimrcByProfileVimrcGvimrc(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installProfileRC(t, "default", "vimrc-nomagic.vim", pathutil.ProfileVimrc)
 	installProfileRC(t, "default", "gvimrc-nomagic.vim", pathutil.ProfileGvimrc)
@@ -341,6 +352,7 @@ func TestVoltBuildT3OverwriteUserGvimrcByProfileGvimrc(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installProfileRC(t, "default", "gvimrc-nomagic.vim", pathutil.ProfileGvimrc)
 	installVimRC(t, "gvimrc-magic.vim", pathutil.Gvimrc)
@@ -366,6 +378,7 @@ func TestVoltBuildT3OverwriteUserVimrcByProfileVimrc(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installProfileRC(t, "default", "vimrc-nomagic.vim", pathutil.ProfileVimrc)
 	installVimRC(t, "vimrc-magic.vim", pathutil.Vimrc)
@@ -391,6 +404,7 @@ func TestVoltBuildT3RemoveUserVimrcGvimrc(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installVimRC(t, "vimrc-magic.vim", pathutil.Vimrc)
 	installVimRC(t, "gvimrc-magic.vim", pathutil.Gvimrc)
@@ -416,6 +430,7 @@ func TestVoltBuildT3InstallGvimrcAndRemoveUserVimrc(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installProfileRC(t, "default", "gvimrc-nomagic.vim", pathutil.ProfileGvimrc)
 	installVimRC(t, "vimrc-magic.vim", pathutil.Vimrc)
@@ -441,6 +456,7 @@ func TestVoltBuildT3InstallVimrcAndRemoveUserGvimrc(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	installProfileRC(t, "default", "vimrc-nomagic.vim", pathutil.ProfileVimrc)
 	installVimRC(t, "gvimrc-magic.vim", pathutil.Gvimrc)
@@ -466,6 +482,7 @@ func TestVoltBuildT4NoVimrcGvimrc(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	// =============== run =============== //
 
@@ -490,6 +507,7 @@ func voltBuildGitNoVimRepos(t *testing.T, full bool, strategy string) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 	reposPathList := []pathutil.ReposPath{"github.com/tyru/caw.vim"}
 	teardown := testutil.SetUpRepos(t, "caw.vim", lockjson.ReposGitType, reposPathList, strategy)
 	defer teardown()
@@ -536,6 +554,7 @@ func voltBuildGitVimDirOlder(t *testing.T, full bool, strategy string) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 	reposPathList := []pathutil.ReposPath{"github.com/tyru/caw.vim"}
 	teardown := testutil.SetUpRepos(t, "caw.vim", lockjson.ReposGitType, reposPathList, strategy)
 	defer teardown()
@@ -587,6 +606,7 @@ func voltBuildGitVimDirNewer(t *testing.T, full bool, strategy string) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 	reposPathList := []pathutil.ReposPath{"github.com/tyru/caw.vim"}
 	teardown := testutil.SetUpRepos(t, "caw.vim", lockjson.ReposGitType, reposPathList, strategy)
 	defer teardown()
@@ -639,6 +659,7 @@ func voltBuildStaticNoVimRepos(t *testing.T, full bool, strategy string) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 	reposPathList := []pathutil.ReposPath{"localhost/local/hello"}
 	teardown := testutil.SetUpRepos(t, "hello", lockjson.ReposStaticType, reposPathList, strategy)
 	defer teardown()
@@ -685,6 +706,7 @@ func voltBuildStaticVimDirOlder(t *testing.T, full bool, strategy string) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 	reposPathList := []pathutil.ReposPath{"localhost/local/hello"}
 	teardown := testutil.SetUpRepos(t, "hello", lockjson.ReposStaticType, reposPathList, strategy)
 	defer teardown()
@@ -736,6 +758,7 @@ func voltBuildStaticVimDirNewer(t *testing.T, full bool, strategy string) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 	reposPathList := []pathutil.ReposPath{"localhost/local/hello"}
 	teardown := testutil.SetUpRepos(t, "hello", lockjson.ReposStaticType, reposPathList, strategy)
 	defer teardown()

--- a/subcmd/get_test.go
+++ b/subcmd/get_test.go
@@ -3,12 +3,13 @@ package subcmd
 import (
 	"bytes"
 	"fmt"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/vim-volt/volt/internal/testutil"
 	"github.com/vim-volt/volt/lockjson"
@@ -54,6 +55,7 @@ func TestVoltGetOnePlugin(t *testing.T) {
 				// =============== setup =============== //
 
 				testutil.SetUpEnv(t)
+				defer testutil.CleanUpEnv(t)
 				testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 				// =============== run =============== //
@@ -111,6 +113,7 @@ func TestVoltGetMsg(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 		reposPath := pathutil.ReposPath("github.com/tyru/caw.vim")
 
@@ -314,6 +317,7 @@ func TestVoltGetTwoOrMorePlugin(t *testing.T) {
 				// =============== setup =============== //
 
 				testutil.SetUpEnv(t)
+				defer testutil.CleanUpEnv(t)
 				testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 				// =============== run =============== //
@@ -378,6 +382,7 @@ func TestVoltGetLoptMustNotAddDisabledPlugins(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	// =============== run =============== //
 
@@ -408,6 +413,7 @@ func TestErrVoltGetInvalidArgs(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	// =============== run =============== //
 
@@ -453,6 +459,7 @@ func TestErrVoltGetNotFound(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	// =============== run =============== //
 

--- a/subcmd/help_test.go
+++ b/subcmd/help_test.go
@@ -12,6 +12,7 @@ func TestVoltHelpDiffOutput(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	// =============== run =============== //
 
@@ -35,6 +36,7 @@ func TestErrVoltHelpNonExistingCmd(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	// =============== run =============== //
 
@@ -50,6 +52,7 @@ func TestVoltHelpE478(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	// =============== run =============== //
 

--- a/subcmd/list_test.go
+++ b/subcmd/list_test.go
@@ -18,6 +18,7 @@ func TestVoltListAndVoltProfileAreSame(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	// =============== run =============== //
 
@@ -43,6 +44,7 @@ func TestVoltListFunctions(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 
@@ -60,6 +62,7 @@ func TestVoltListFunctions(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 
@@ -81,6 +84,7 @@ func TestVoltListFunctions(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 
@@ -98,6 +102,7 @@ func TestVoltListFunctions(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 
@@ -115,6 +120,7 @@ func TestVoltListFunctions(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 
@@ -133,6 +139,7 @@ func TestVoltListFunctions(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 
@@ -151,6 +158,7 @@ func TestVoltListFunctions(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 

--- a/subcmd/profile_test.go
+++ b/subcmd/profile_test.go
@@ -29,6 +29,7 @@ func TestVoltProfileSet(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 
 			reposPathList := []pathutil.ReposPath{pathutil.ReposPath("github.com/tyru/caw.vim")}
 			teardown := testutil.SetUpRepos(t, "caw.vim", lockjson.ReposGitType, reposPathList, strategy)
@@ -73,6 +74,7 @@ func TestVoltProfileSet(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 			testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 			// =============== run =============== //
@@ -98,6 +100,7 @@ func TestVoltProfileSet(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 			testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 			// =============== run =============== //
@@ -131,6 +134,7 @@ func TestVoltProfileShow(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 
@@ -153,6 +157,7 @@ func TestVoltProfileShow(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 
@@ -173,6 +178,7 @@ func TestVoltProfileShow(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 
@@ -200,6 +206,7 @@ func TestVoltProfileList(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 
@@ -218,6 +225,7 @@ func TestVoltProfileList(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		out, err := testutil.RunVolt("profile", "new", "foo")
 		testutil.SuccessExit(t, out, err)
 
@@ -247,6 +255,7 @@ func TestVoltProfileNew(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 
@@ -272,6 +281,7 @@ func TestVoltProfileNew(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 
@@ -297,6 +307,7 @@ func TestVoltProfileNew(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		out, err := testutil.RunVolt("profile", "new", "bar")
 		testutil.SuccessExit(t, out, err)
 
@@ -332,6 +343,7 @@ func TestVoltProfileDestroy(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		out, err := testutil.RunVolt("profile", "new", "foo")
 		// (A, B)
 		testutil.SuccessExit(t, out, err)
@@ -356,6 +368,7 @@ func TestVoltProfileDestroy(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 
@@ -377,6 +390,7 @@ func TestVoltProfileDestroy(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		// =============== run =============== //
 
@@ -403,6 +417,7 @@ func TestVoltProfileRename(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		out, err := testutil.RunVolt("profile", "set", "-n", "foo")
 		testutil.SuccessExit(t, out, err)
 
@@ -441,6 +456,7 @@ func TestVoltProfileRename(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		oldLockJSON, err := lockjson.Read()
 		if err != nil {
 			t.Error("lockjson.Read() returned non-nil error: " + err.Error())
@@ -480,6 +496,7 @@ func TestVoltProfileRename(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		out, err := testutil.RunVolt("profile", "new", "foo")
 		testutil.SuccessExit(t, out, err)
 		out, err = testutil.RunVolt("profile", "new", "bar")
@@ -520,6 +537,7 @@ func TestVoltProfileRename(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		out, err := testutil.RunVolt("profile", "new", "foo")
 		testutil.SuccessExit(t, out, err)
 
@@ -558,6 +576,7 @@ func TestVoltProfileRename(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		out, err := testutil.RunVolt("profile", "new", "foo")
 		testutil.SuccessExit(t, out, err)
 
@@ -596,6 +615,7 @@ func TestVoltProfileRename(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 
 		oldLockJSON, err := lockjson.Read()
 		if err != nil {
@@ -646,6 +666,7 @@ func TestVoltProfileAdd(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 
 			reposPathList := []pathutil.ReposPath{pathutil.ReposPath("github.com/tyru/caw.vim")}
 			teardown := testutil.SetUpRepos(t, "caw.vim", lockjson.ReposGitType, reposPathList, config.SymlinkBuilder)
@@ -691,6 +712,7 @@ func TestVoltProfileAdd(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 
 			reposPathList := pathutil.ReposPathList{pathutil.ReposPath("github.com/tyru/caw.vim"), pathutil.ReposPath("github.com/tyru/capture.vim")}
 			teardown := testutil.SetUpRepos(t, "caw-and-capture", lockjson.ReposGitType, reposPathList, config.SymlinkBuilder)
@@ -738,6 +760,7 @@ func TestVoltProfileAdd(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 
 			reposPathList := pathutil.ReposPathList{pathutil.ReposPath("github.com/tyru/caw.vim")}
 			teardown := testutil.SetUpRepos(t, "caw.vim", lockjson.ReposGitType, reposPathList, config.SymlinkBuilder)
@@ -783,6 +806,7 @@ func TestVoltProfileAdd(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 
 			reposPathList := pathutil.ReposPathList{pathutil.ReposPath("github.com/tyru/caw.vim")}
 			teardown := testutil.SetUpRepos(t, "caw.vim", lockjson.ReposGitType, reposPathList, config.SymlinkBuilder)
@@ -820,6 +844,7 @@ func TestVoltProfileAdd(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 			testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 			out, err := testutil.RunVolt("profile", "new", "empty")
@@ -861,6 +886,7 @@ func TestVoltProfileAdd(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 			testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 			oldLockJSON, err := lockjson.Read()
@@ -907,6 +933,7 @@ func TestVoltProfileRm(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 
 			reposPathList := pathutil.ReposPathList{pathutil.ReposPath("github.com/tyru/caw.vim")}
 			teardown := testutil.SetUpRepos(t, "caw.vim", lockjson.ReposGitType, reposPathList, config.SymlinkBuilder)
@@ -949,6 +976,7 @@ func TestVoltProfileRm(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 
 			reposPathList := pathutil.ReposPathList{pathutil.ReposPath("github.com/tyru/caw.vim"), pathutil.ReposPath("github.com/tyru/capture.vim")}
 			teardown := testutil.SetUpRepos(t, "caw-and-capture", lockjson.ReposGitType, reposPathList, config.SymlinkBuilder)
@@ -993,6 +1021,7 @@ func TestVoltProfileRm(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 
 			reposPathList := pathutil.ReposPathList{pathutil.ReposPath("github.com/tyru/caw.vim")}
 			teardown := testutil.SetUpRepos(t, "caw.vim", lockjson.ReposGitType, reposPathList, config.SymlinkBuilder)
@@ -1035,6 +1064,7 @@ func TestVoltProfileRm(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 
 			reposPathList := pathutil.ReposPathList{pathutil.ReposPath("github.com/tyru/caw.vim")}
 			teardown := testutil.SetUpRepos(t, "caw.vim", lockjson.ReposGitType, reposPathList, config.SymlinkBuilder)
@@ -1072,6 +1102,7 @@ func TestVoltProfileRm(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 			testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 			oldLockJSON, err := lockjson.Read()
@@ -1110,6 +1141,7 @@ func TestVoltProfileRm(t *testing.T) {
 			// =============== setup =============== //
 
 			testutil.SetUpEnv(t)
+			defer testutil.CleanUpEnv(t)
 			testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 			oldLockJSON, err := lockjson.Read()

--- a/subcmd/rm_test.go
+++ b/subcmd/rm_test.go
@@ -27,6 +27,7 @@ func TestVoltRmOnePlugin(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 		out, err := testutil.RunVolt("get", "tyru/caw.vim")
@@ -68,6 +69,7 @@ func TestVoltRmRoptOnePlugin(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 		out, err := testutil.RunVolt("get", "tyru/caw.vim")
@@ -109,6 +111,7 @@ func TestVoltRmOnePluginNoPlugconf(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 		out, err := testutil.RunVolt("get", "tyru/caw.vim")
@@ -147,6 +150,7 @@ func TestVoltRmTwoOrMorePluginNoPlugconf(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 		out, err := testutil.RunVolt("get", "tyru/caw.vim", "tyru/capture.vim")
@@ -191,6 +195,7 @@ func TestVoltRmOnePluginNoRepos(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 		out, err := testutil.RunVolt("get", "tyru/caw.vim")
@@ -229,6 +234,7 @@ func TestVoltRmOnePluginNoReposNoPlugconf(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 		out, err := testutil.RunVolt("get", "tyru/caw.vim")
@@ -264,6 +270,7 @@ func TestVoltRmPoptOnePlugin(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 		out, err := testutil.RunVolt("get", "tyru/caw.vim")
@@ -305,6 +312,7 @@ func TestVoltRmPoptOnePluginNoPlugconf(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 		out, err := testutil.RunVolt("get", "tyru/caw.vim")
@@ -343,6 +351,7 @@ func TestVoltRmPoptOnePluginNoRepos(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 		out, err := testutil.RunVolt("get", "tyru/caw.vim")
@@ -381,6 +390,7 @@ func TestVoltRmPoptTwoOrMorePluginNoPlugconf(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 		out, err := testutil.RunVolt("get", "tyru/caw.vim", "tyru/capture.vim")
@@ -425,6 +435,7 @@ func TestVoltRmPoptOnePluginNoReposNoPlugconf(t *testing.T) {
 		// =============== setup =============== //
 
 		testutil.SetUpEnv(t)
+		defer testutil.CleanUpEnv(t)
 		testutil.InstallConfig(t, "strategy-"+strategy+".toml")
 
 		out, err := testutil.RunVolt("get", "tyru/caw.vim")
@@ -459,6 +470,7 @@ func TestErrVoltRmInvalidArgs(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	// =============== run =============== //
 
@@ -472,6 +484,7 @@ func TestErrVoltRmNotFound(t *testing.T) {
 	// =============== setup =============== //
 
 	testutil.SetUpEnv(t)
+	defer testutil.CleanUpEnv(t)
 
 	// =============== run =============== //
 


### PR DESCRIPTION
Test directories that are created for testing are removed after
successful tests. Otherwise they clutter the tmp dir after executing
lots of tests.

There are still some volt-test-home* directories created that this PR doesn't catch.