### PR TITLE
[CI] Test only the nearest two major go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ matrix:
       go: 1.9
     - os: linux
       go: 1.11
-      env: GO111MODULE="on"
+      env: GO111MODULE="on" GOFLAGS=-mod=readonly
     - os: linux
       go: 1.11
-      env: GO111MODULE="off"
+      env: GO111MODULE="off" GOFLAGS=-mod=readonly
     - os: linux
       go: tip
-      env: GO111MODULE="on"
+      env: GO111MODULE="on" GOFLAGS=-mod=readonly
     # macOS build *extraordinary* slow, disable them
     # - os: osx
     #   osx_image: xcode8.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,11 @@ language: go
 matrix:
   include:
     - os: linux
-      go: 1.9
+      go: 1.11.10
+      env: GO111MODULE="on"
     - os: linux
-      go: 1.11
-      env: GO111MODULE="on" GOFLAGS=-mod=readonly
-    - os: linux
-      go: 1.11
-      env: GO111MODULE="off" GOFLAGS=-mod=readonly
-    - os: linux
-      go: tip
-      env: GO111MODULE="on" GOFLAGS=-mod=readonly
+      go: 1.12.5
+      env: GO111MODULE="on"
     # macOS build *extraordinary* slow, disable them
     # - os: osx
     #   osx_image: xcode8.3

--- a/go.mod
+++ b/go.mod
@@ -22,3 +22,5 @@ require (
 	gopkg.in/src-d/go-git.v4 v4.0.0-rc15
 	gopkg.in/warnings.v0 v0.1.2
 )
+
+go 1.12.5


### PR DESCRIPTION
On the latest go command appends `go 1.13` at the bottom of `go.mod`.

https://travis-ci.org/vim-volt/volt/jobs/537348218

```
$ go version
go version devel +d97bd5d07a Sat May 25 22:38:01 2019 +0000 linux/amd64
```

This PR avoids that.