### PR TITLE
Return actual error when updating repos

### DIFF
--- a/subcmd/builder/symlink.go
+++ b/subcmd/builder/symlink.go
@@ -78,7 +78,7 @@ func (builder *symlinkBuilder) Build(buildInfo *buildinfo.BuildInfo, buildReposM
 	for i := 0; i < len(reposList); i++ {
 		result := <-done
 		if result.err != nil {
-			return err
+			return result.err
 		}
 		if result.repos != nil {
 			logger.Debug("Installing " + string(result.repos.Type) + " repository " + result.repos.Path.String() + " ... Done.")


### PR DESCRIPTION
At the moment the actual error is ignored an a nil error is always
returned. This leads to the surprising result that only some arbitrary
repositories are symlinked on `volt build` if one update failed, but no
error is displayed to the user.