### PR TITLE
Fix go.mod error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,4 @@ require (
 	gopkg.in/warnings.v0 v0.1.2
 )
 
-go 1.12.5
+go 1.12


### PR DESCRIPTION
go.mod does not accept a patch version.

```
github.com/vim-volt/volt/go.mod:26: usage: go 1.23
```