### PR TITLE
Fix dep tree

### DIFF
--- a/plugconf/plugconf.go
+++ b/plugconf/plugconf.go
@@ -882,7 +882,9 @@ func visitNode(node *reposDepNode, callback func(*reposDepNode), visited map[pat
 }
 
 func makeRank(rank map[pathutil.ReposPath]int, node *reposDepNode, value int) {
-	rank[node.repos.Path] = value
+	if r, ok := rank[node.repos.Path]; !ok || r < value {
+		rank[node.repos.Path] = value
+	}
 	for i := range node.dependedBy {
 		makeRank(rank, node.dependedBy[i], value+1)
 	}

--- a/plugconf/plugconf.go
+++ b/plugconf/plugconf.go
@@ -589,8 +589,8 @@ type reposDepTree struct {
 
 type reposDepNode struct {
 	repos      *lockjson.Repos
-	dependTo   []reposDepNode
-	dependedBy []reposDepNode
+	dependTo   []*reposDepNode
+	dependedBy []*reposDepNode
 }
 
 // ParseMultiPlugconf parses plugconfs of given reposList.
@@ -858,11 +858,11 @@ func makeNodes(reposPath pathutil.ReposPath, reposMap map[pathutil.ReposPath]*lo
 	visited[reposPath] = node
 	for i := range depsMap[reposPath] {
 		dep := makeNodes(depsMap[reposPath][i], reposMap, depsMap, rdepsMap, visited)
-		node.dependTo = append(node.dependTo, *dep)
+		node.dependTo = append(node.dependTo, dep)
 	}
 	for i := range rdepsMap[reposPath] {
 		rdep := makeNodes(rdepsMap[reposPath][i], reposMap, depsMap, rdepsMap, visited)
-		node.dependedBy = append(node.dependedBy, *rdep)
+		node.dependedBy = append(node.dependedBy, rdep)
 	}
 	return node
 }
@@ -874,17 +874,17 @@ func visitNode(node *reposDepNode, callback func(*reposDepNode), visited map[pat
 	visited[node.repos.Path] = true
 	callback(node)
 	for i := range node.dependTo {
-		visitNode(&node.dependTo[i], callback, visited)
+		visitNode(node.dependTo[i], callback, visited)
 	}
 	for i := range node.dependedBy {
-		visitNode(&node.dependedBy[i], callback, visited)
+		visitNode(node.dependedBy[i], callback, visited)
 	}
 }
 
 func makeRank(rank map[pathutil.ReposPath]int, node *reposDepNode, value int) {
 	rank[node.repos.Path] = value
 	for i := range node.dependedBy {
-		makeRank(rank, &node.dependedBy[i], value+1)
+		makeRank(rank, node.dependedBy[i], value+1)
 	}
 }
 

--- a/plugconf/plugconf_test.go
+++ b/plugconf/plugconf_test.go
@@ -45,6 +45,43 @@ func TestSortByDepends(t *testing.T) {
 				{Path: pathutil.DecodeReposPath("test/test-1")},
 			},
 		},
+		{
+			input: input{
+				reposList: []lockjson.Repos{
+					{Path: pathutil.DecodeReposPath("Shougo/ddc-matcher_head")},
+					{Path: pathutil.DecodeReposPath("Shougo/ddc.vim")},
+					{Path: pathutil.DecodeReposPath("shun/ddc-vim-lsp")},
+					{Path: pathutil.DecodeReposPath("vim-denops/denops.vim")},
+				},
+				plugconfMap: map[pathutil.ReposPath]*ParsedInfo{
+					pathutil.DecodeReposPath("vim-denops/denops.vim"): {},
+					pathutil.DecodeReposPath("Shougo/ddc.vim"): {
+						depends: []pathutil.ReposPath{
+							pathutil.DecodeReposPath("vim-denops/denops.vim"),
+						},
+					},
+					pathutil.DecodeReposPath("Shougo/ddc-matcher_head"): {
+						depends: []pathutil.ReposPath{
+							pathutil.DecodeReposPath("vim-denops/denops.vim"),
+							pathutil.DecodeReposPath("Shougo/ddc.vim"),
+						},
+					},
+					pathutil.DecodeReposPath("shun/ddc-vim-lsp"): {
+						depends: []pathutil.ReposPath{
+							pathutil.DecodeReposPath("vim-denops/denops.vim"),
+							pathutil.DecodeReposPath("Shougo/ddc.vim"),
+							pathutil.DecodeReposPath("Shougo/ddc-matcher_head"),
+						},
+					},
+				},
+			},
+			want: []lockjson.Repos{
+				{Path: pathutil.DecodeReposPath("vim-denops/denops.vim")},
+				{Path: pathutil.DecodeReposPath("Shougo/ddc.vim")},
+				{Path: pathutil.DecodeReposPath("Shougo/ddc-matcher_head")},
+				{Path: pathutil.DecodeReposPath("shun/ddc-vim-lsp")},
+			},
+		},
 	}
 
 	for _, tt := range cases {

--- a/plugconf/plugconf_test.go
+++ b/plugconf/plugconf_test.go
@@ -1,0 +1,57 @@
+package plugconf
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/vim-volt/volt/lockjson"
+	"github.com/vim-volt/volt/pathutil"
+)
+
+func TestSortByDepends(t *testing.T) {
+	type input struct {
+		reposList   []lockjson.Repos
+		plugconfMap map[pathutil.ReposPath]*ParsedInfo
+	}
+
+	cases := []struct {
+		input input
+		want  []lockjson.Repos
+	}{
+		{
+			input: input{
+				reposList: []lockjson.Repos{
+					{Path: pathutil.DecodeReposPath("test/test-1")},
+					{Path: pathutil.DecodeReposPath("test/test-2")},
+					{Path: pathutil.DecodeReposPath("test/test-3")},
+				},
+				plugconfMap: map[pathutil.ReposPath]*ParsedInfo{
+					pathutil.DecodeReposPath("test/test-1"): {
+						depends: []pathutil.ReposPath{
+							pathutil.DecodeReposPath("test/test-2"),
+						},
+					},
+					pathutil.DecodeReposPath("test/test-2"): {
+						depends: []pathutil.ReposPath{
+							pathutil.DecodeReposPath("test/test-3"),
+						},
+					},
+					pathutil.DecodeReposPath("test/test-3"): {},
+				},
+			},
+			want: []lockjson.Repos{
+				{Path: pathutil.DecodeReposPath("test/test-3")},
+				{Path: pathutil.DecodeReposPath("test/test-2")},
+				{Path: pathutil.DecodeReposPath("test/test-1")},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		sortByDepends(tt.input.reposList, tt.input.plugconfMap)
+
+		if !reflect.DeepEqual(tt.input.reposList, tt.want) {
+			t.Fatalf("want: %v, but got: %v", tt.want, tt.input.reposList)
+		}
+	}
+}


### PR DESCRIPTION
close: #332 

- The `dependTo`/`dependedBy` fields were not slices of pointers, so the updated values were not reflected.
- The first value calculated was used as rank, so the result of rank calculation depended on the order before sorting.