### PR TITLE
Added support for `go install`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,4 @@ require (
 	gopkg.in/warnings.v0 v0.1.2
 )
 
-go 1.12.5
+go 1.12


### PR DESCRIPTION
fixes #335, go does not publish using semver.